### PR TITLE
fix: pyright: pre-commit dependencies

### DIFF
--- a/python/pyproject.toml.j2
+++ b/python/pyproject.toml.j2
@@ -44,6 +44,7 @@ include = ["src", "tests"]
 pythonVersion = "3.12"
 pythonPlatform = "Linux"
 typeCheckingMode = "strict"
+venvPath = "."
 venv = ".venv"
 
 [tool.black]


### PR DESCRIPTION
As desdcribed in documentation (https://github.com/RobertCraigie/pyright-python?tab=readme-ov-file#pre-commit) pre-commit installs pyright-python in its own virtual environment. So pyright is not be able to detect the dependencies. To fix it we have to specify the path of the virtual environment to use.