### PR TITLE
feat: markdown formater

### DIFF
--- a/python/README.md.j2
+++ b/python/README.md.j2
@@ -6,6 +6,7 @@
 ![PDM](https://img.shields.io/badge/pdm-managed-blueviolet)
 ![Black](https://img.shields.io/badge/code_style-black-000000)
 ![Isort](https://img.shields.io/badge/imports-isort-1674b1?labelColor=ef8336)
+![Mdformat](https://img.shields.io/badge/docs-mdformat-000000?labelColor=1674b1)
 ![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)
 [![Checked with pyright](https://microsoft.github.io/pyright/img/pyright_badge.svg)](https://microsoft.github.io/pyright/)
 ![Pre Commit](https://img.shields.io/badge/pre_commit-enabled-brightgreen?logo=pre-commit)

--- a/python/pyproject.toml.j2
+++ b/python/pyproject.toml.j2
@@ -112,6 +112,10 @@ _isort_format = { cmd = [
     "./src",
     "tests/",
 ], help = "Format of the imports" }
+_mdformat_format = { cmd = [
+    "mdformat",
+    ".",
+], help = "Format the markdown files" }
 _black_check = { cmd = [
     "black",
     # Do not actually format the code
@@ -126,6 +130,12 @@ _isort_check = { cmd = [
     "./src",
     "tests/",
 ], help = "Check the formatting of the imports" }
+_mdformat_check = { cmd = [
+    "mdformat",
+    # Do not actually format the markdown files
+    "--check",
+    ".",
+], help = "Check the formatting of the the markdown files" }
 _ruff_check = { cmd = [
     "ruff",
     # Do not actually fix the code
@@ -233,6 +243,7 @@ _build_wheel = { cmd = [
 format = { composite = [
     "_black_format",
     "_isort_format",
+    "_mdformat_format",
 ], help = "Format the codebase" }
 spell = { composite = [
     "_typos_fix",
@@ -240,6 +251,7 @@ spell = { composite = [
 lint = { composite = [
     "_black_check",
     "_isort_check",
+    "_mdformat_check",
     "_pyright_check",
     "_ruff_check",
     "_typos_check",
@@ -307,6 +319,7 @@ dev = [
     "copier~=9.1",
     "coverage~=7.4",
     "isort~=5.13",
+    "mdformat~=0.7",
     "pex~=2.1",
     "pre-commit~=3.6",
     "pyclean~=2.7",

--- a/python/readme/Quickstart.md
+++ b/python/readme/Quickstart.md
@@ -90,7 +90,7 @@ in your `$PATH`. We recommend the use of
 
 `pdm format`
 
-This will run `black` and `isort` on the `src/` and `tests/` directories,
+This will run `black`, `isort` and `mdformat` on the `src/` and `tests/` directories,
 formatting your code properly.
 
 ### ...spellcheck my project?
@@ -103,7 +103,7 @@ It will run `typos` on the entire project, and fix any typo it finds.
 
 `pdm lint`
 
-This will call various linters (`black`, `isort`, `ruff`, `pyright`, `typos`), and
+This will call various linters (`black`, `isort`, `mdformat`,`ruff`, `pyright`, `typos`), and
 tell you if your code passes them.
 
 ### ...generate test coverage?


### PR DESCRIPTION
The template uses mdformat (https://github.com/executablebooks/mdformat) to check and format all markdown files in the project. The `pdm format` command now also formats markdown files. The `pdm lint` command  now also checks markdown files.