### PR TITLE
fix: python: quote a command expansion to avoid word splitting

### DIFF
--- a/python/Dockerfile.j2
+++ b/python/Dockerfile.j2
@@ -36,6 +36,6 @@ FROM base as final
 ENV PATH="/app/.venv/bin:${PATH}"
 COPY --from=dependencies-installer /app/.venv/ /app/.venv/
 COPY --from=package-builder /app/dist/{{ package_name }}*.whl /app/
-RUN pip --python $(which python) install --no-cache-dir --no-deps ./{{ package_name }}*.whl
+RUN pip --python "$(which python)" install --no-cache-dir --no-deps ./{{ package_name }}*.whl
 
 ENTRYPOINT [ "{{ package_name }}" ]


### PR DESCRIPTION
Fixes #7